### PR TITLE
Fixed `Process::sender()` panic when downcasting.

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -54,10 +54,12 @@ impl Processor {
                 entry.insert(Box::new(Processes::<A::Context> { receiver }));
                 sender
             }
-            Entry::Occupied(entry) => Any::downcast_ref::<Processes<A::Context>>(&*entry.get())
-                .unwrap()
-                .receiver
-                .sender(),
+            Entry::Occupied(entry) => {
+                Any::downcast_ref::<Processes<A::Context>>(entry.get().as_ref())
+                    .unwrap()
+                    .receiver
+                    .sender()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #9.