### PR TITLE
Removed `Clone` bound from assets.

### DIFF
--- a/src/asset.rs
+++ b/src/asset.rs
@@ -16,7 +16,7 @@ use core::fmt::Display;
 /// that are produced by `Format` implemetations.
 ///
 /// [`Format`]: ./trait.Format.html
-pub trait Asset: MaybeSend + MaybeSync + Sized + Clone + 'static {
+pub trait Asset: MaybeSend + MaybeSync + Sized + 'static {
     /// Error that may occur during asset building.
     #[cfg(feature = "std")]
     type Error: Error + MaybeSend + MaybeSync;
@@ -82,7 +82,7 @@ pub trait AssetDefaultFormat<K>: Asset {
 /// Shortcut for implementing [`Asset`] when asset building is synchronous.
 ///
 /// [`Asset`]: ./trait.Asset.html
-pub trait SyncAsset: MaybeSend + MaybeSync + Sized + Clone + 'static {
+pub trait SyncAsset: MaybeSend + MaybeSync + Sized + 'static {
     /// Error that may occur during asset building.
     #[cfg(feature = "std")]
     type Error: Error + MaybeSend + MaybeSync;
@@ -132,7 +132,7 @@ pub struct PhantomContext;
 ///
 /// [`Asset`]: ./trait.Asset.html
 /// [`Format`]: ./trait.Format.html
-pub trait SimpleAsset: MaybeSend + MaybeSync + Sized + Clone + 'static {}
+pub trait SimpleAsset: MaybeSend + MaybeSync + Sized + 'static {}
 
 impl<S> SyncAsset for S
 where

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -23,9 +23,16 @@ use {
 /// to the place where asset isntance will be.
 /// So polling `Handle` isn't necessary for asset to be loaded.
 /// When asset is finally loaded any task that polled `Handle` will be notified.
-#[derive(Clone)]
 pub struct Handle<A: Asset> {
     state: Rc<State<A>>,
+}
+
+impl<A: Asset> Clone for Handle<A> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+        }
+    }
 }
 
 impl<A> Eq for Handle<A> where A: Asset {}
@@ -73,7 +80,7 @@ where
 
 impl<A> Future for Handle<A>
 where
-    A: Asset,
+    A: Asset + Clone,
 {
     type Output = Result<A, Error<A>>;
 


### PR DESCRIPTION
As far as I know, `Clone` is a requirement for assets only because of the `Future` implementation for `Handle`; if so, it makes sense to require that bound only for said implementation.